### PR TITLE
Fix linux font typo (sans-self -> sans-serif), update macos diff font (Hiragino Sans Mono -> BIZ UDGothic)

### DIFF
--- a/src/core/font.rs
+++ b/src/core/font.rs
@@ -5,7 +5,7 @@ const APP_DEFAULT_FONT: &str = "Yu Gothic";
 const APP_DEFAULT_FONT: &str = "Hiragino Sans";
 
 #[cfg(target_os = "linux")]
-const APP_DEFAULT_FONT: &str = "sans-self";
+const APP_DEFAULT_FONT: &str = "sans-serif";
 
 /// get app font on non-linux
 #[cfg(not(target_os = "linux"))]
@@ -44,7 +44,7 @@ fn linux_app_default_font() -> &'static str {
 const DIFF_FONT: &str = "BIZ UDGothic";
 
 #[cfg(target_os = "macos")]
-const DIFF_FONT: &str = "Hiragino Sans Mono";
+const DIFF_FONT: &str = "BIZ UDGothic";
 
 #[cfg(target_os = "linux")]
 const DIFF_FONT: &str = "monospace";


### PR DESCRIPTION
On recent versions of macOS, Hiragino Sans Mono is not available, which causes diffs to render incorrectly.
Ideally, we'd use SF Mono as the monospace font, but it doesn't fall back to Japanese properly, so we use BIZ UDGothic as a practical alternative.

## Current

<img width="1024" height="286" alt="Screenshot 2026-05-02 at 9 47 34" src="https://github.com/user-attachments/assets/62f62bf1-8c87-44ae-b9b9-343a03d38572" />

## Post fix

<img width="1024" height="272" alt="Screenshot 2026-05-02 at 10 08 16" src="https://github.com/user-attachments/assets/224a512f-25ab-4381-aa64-e9ff100d7991" />
